### PR TITLE
Replace the null logger so issues can be surfaced in debug.log. See #86

### DIFF
--- a/docs/composer.md
+++ b/docs/composer.md
@@ -57,7 +57,7 @@ gravityforms
 
 ## Configuring Authentication
 
-It's also possible configure Composer to use your API Key by running the `config` command:
+It's also possible to configure Composer to use your API Key by running the `config` command:
 
 ```sh
 $ composer config http-basic.packages.example.com \

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,10 +1,25 @@
 # Logging
 
-SatisPress implements a [PSR-3 Logger Interface](https://www.php-fig.org/psr/psr-3/) for logging messages, but doesn't save them by default. To view messages, a logger implementing `Psr\Log\LoggerInterface` needs to be registered with the container.
+SatisPress implements a [PSR-3 Logger Interface](https://www.php-fig.org/psr/psr-3/) for logging messages when `WP_DEBUG` is enabled. The default implementation only logs messages with a [log level](https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel) of `warning` or higher.
 
-## Example
+Messages are logged via PHP's `error_log()` function, which typically saves them to the `wp-content/debug.log` file when `WP_DEBUG` is enabled.
 
-The example below demonstrates how to retrieve the SatisPress container and register a new logger. It uses [Monolog](https://github.com/Seldaek/monolog) to send warning messages through PHP's `error_log()` handler:
+## Changing the Log Level
+
+To log more or less information, the log level can be adjusted in the DI container.
+
+```php
+<?php
+add_action( 'satispress_compose', function( $plugin, $container ) {
+	$container['logger.level'] = 'debug';
+}, 10, 2 );
+```
+
+_Assigning an empty string or invalid level will prevent messages from being logged, effectively disabling the logger._
+
+## Registering a Custom Logger
+
+The example below demonstrates how to retrieve the SatisPress container and register a new logger to replace the default logger. It uses [Monolog](https://github.com/Seldaek/monolog) to send warning messages through PHP's `error_log()` handler:
 
 ```php
 <?php

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Default logger.
+ *
+ * Logs messages to error_log().
+ *
+ * @package SatisPress
+ * @license GPL-2.0-or-later
+ * @since 0.4.0
+ */
+
+declare ( strict_types = 1 );
+
+namespace SatisPress;
+
+use DateTime;
+use Exception;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use ReflectionClass;
+
+/**
+ * Default logger class.
+ *
+ * @since 0.4.0
+ */
+final class Logger extends AbstractLogger {
+	/**
+	 * PSR log levels.
+	 *
+	 * @since 0.4.0
+	 * @var array
+	 */
+	protected $levels = [
+		LogLevel::DEBUG,
+		LogLevel::INFO,
+		LogLevel::NOTICE,
+		LogLevel::WARNING,
+		LogLevel::ERROR,
+		LogLevel::CRITICAL,
+		LogLevel::ALERT,
+		LogLevel::EMERGENCY,
+	];
+
+	/**
+	 * Minimum log level.
+	 *
+	 * @since 0.4.0
+	 * @var int
+	 */
+	protected $minimium_level_code;
+
+	/**
+	 * Constructor method.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param string $minimum_level Minimum level to log.
+	 */
+	public function __construct( string $minimum_level ) {
+		$this->minimium_level_code = $this->get_level_code( $minimum_level );
+	}
+
+	/**
+	 * Log a message.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param string $level   PSR log level.
+	 * @param string $message Log message.
+	 * @param array  $context Additional data.
+	 */
+	public function log( $level, $message, array $context = [] ) {
+		if ( ! $this->handle_level( $level ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log(
+			sprintf(
+				'SATISPRESS.%s: %s',
+				strtoupper( $level ),
+				$this->format( $message, $context )
+			)
+		);
+	}
+
+	/**
+	 * Format a message.
+	 *
+	 * - Interpolates context values into message placeholders.
+	 * - Appends additional context data as JSON.
+	 * - Appends exception data.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param string $message Log message.
+	 * @param array  $context Additional data.
+	 * @return string
+	 */
+	protected function format( string $message, array $context = [] ): string {
+		$search  = [];
+		$replace = [];
+
+		// Extract exceptions from the context array.
+		$exception = $context['exception'] ?? null;
+		unset( $context['exception'] );
+
+		foreach ( $context as $key => $value ) {
+			$placeholder = '{' . $key . '}';
+
+			if ( false === strpos( $message, $placeholder ) ) {
+				continue;
+			}
+
+			array_push( $search, '{' . $key . '}' );
+			array_push( $replace, $this->to_string( $value ) );
+			unset( $context[ $key ] );
+		}
+
+		$line = str_replace( $search, $replace, $message );
+
+		// Append additional context data.
+		if ( ! empty( $context ) ) {
+			$line .= ' ' . wp_json_encode( $context, \JSON_UNESCAPED_SLASHES );
+		}
+
+		// Append an exception.
+		if ( ! empty( $exception ) && $exception instanceof Exception ) {
+			$line .= ' ' . $this->format_exception( $exception );
+		}
+
+		return $line;
+	}
+
+	/**
+	 * Format an exception.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param Exception $e Exception.
+	 * @return string
+	 */
+	protected function format_exception( Exception $e ): string {
+		return wp_json_encode(
+			[
+				'message' => $e->getMessage(),
+				'code'    => $e->getCode(),
+				'file'    => $e->getFile(),
+				'line'    => $e->getLine(),
+				'trace'   => $e->getTrace(),
+			],
+			\JSON_UNESCAPED_SLASHES
+		);
+	}
+
+	/**
+	 * Convert a value to a string.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param mixed $value Message.
+	 * @return string
+	 */
+	protected function to_string( $value ): string {
+		if ( is_wp_error( $value ) ) {
+			$value = $value->get_error_message();
+		} elseif ( is_object( $value ) && method_exists( '__toString', $value ) ) {
+			$value = (string) $value;
+		} elseif ( ! is_scalar( $value ) ) {
+			$value = wp_json_encode( $value, \JSON_UNESCAPED_SLASHES );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Whether a message with a given level should be logged.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param mixed $level PSR Log level.
+	 * @return bool
+	 */
+	protected function handle_level( $level ): bool {
+		return $this->minimum_level_code >= 0 && $this->minimum_level_code >= $this->get_level_code( $level );
+	}
+
+	/**
+	 * Retrieve a numeric code for a given PSR log level.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param mixed $level PSR log level.
+	 * @return int
+	 */
+	protected function get_level_code( $level ) {
+		$code = array_search( $level, $this->levels, true );
+		return false === $code ? -1 : $code;
+	}
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,11 +17,12 @@ use Pimple\Container as PimpleContainer;
 use Pimple\ServiceIterator;
 use Pimple\ServiceProviderInterface;
 use Pimple\Psr11\ServiceLocator;
-use Psr\Log\NullLogger;
+use Psr\Log\LogLevel;
 use SatisPress\Authentication\ApiKey;
 use SatisPress\Authentication;
 use SatisPress\HTTP\Request;
 use SatisPress\Integration;
+use SatisPress\Logger;
 use SatisPress\PackageType\Plugin;
 use SatisPress\PackageType\Theme;
 use SatisPress\Provider;
@@ -167,7 +168,16 @@ class ServiceProvider implements ServiceProviderInterface {
 		};
 
 		$container['logger'] = function( $container ) {
-			return new NullLogger();
+			return new Logger( $container['logger.level'] );
+		};
+
+		$container['logger.level'] = function( $container ) {
+			// Log warnings and above when WP_DEBUG is enabled.
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				$level = LogLevel::WARNING;
+			}
+
+			return $level ?? '';
 		};
 
 		$container['package.factory'] = function( $container ) {


### PR DESCRIPTION
This introduces a basic logger implementation to log messages to debug.log via
error_log(). By default, only messages with a "warning" level or higher will be
logged when WP_DEBUG is enabled.