### PR TITLE
Handle empty and malformed $_SERVER request variables

### DIFF
--- a/src/Provider/Authentication.php
+++ b/src/Provider/Authentication.php
@@ -183,6 +183,11 @@ class Authentication extends AbstractHookProvider {
 	 * @return string
 	 */
 	protected function get_request_path(): string {
+
+		if( !isset( $_SERVER['REQUEST_URI'] ) ) {
+			return '';
+		}
+
 		$request_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 
 		$wp_base = get_home_url( null, '/', 'relative' );

--- a/src/Provider/Authentication.php
+++ b/src/Provider/Authentication.php
@@ -183,12 +183,11 @@ class Authentication extends AbstractHookProvider {
 	 * @return string
 	 */
 	protected function get_request_path(): string {
+		$request_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 
-		if( !isset( $_SERVER['REQUEST_URI'] ) ) {
+		if ( false === $request_path ) {
 			return '';
 		}
-
-		$request_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 
 		$wp_base = get_home_url( null, '/', 'relative' );
 		if ( $request_path && 0 === strpos( $request_path, $wp_base ) ) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -153,6 +153,11 @@ class ServiceProvider implements ServiceProviderInterface {
 		};
 
 		$container['http.request'] = function() {
+
+			if( wp_doing_cron() ) {
+				return new Request();
+			}
+
 			$request = new Request( $_SERVER['REQUEST_METHOD'] );
 
 			// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -154,11 +154,7 @@ class ServiceProvider implements ServiceProviderInterface {
 
 		$container['http.request'] = function() {
 
-			if( wp_doing_cron() ) {
-				return new Request();
-			}
-
-			$request = new Request( $_SERVER['REQUEST_METHOD'] );
+			$request = new Request( $_SERVER['REQUEST_METHOD'] ?? '' );
 
 			// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 			$request->set_query_params( wp_unslash( $_GET ) );


### PR DESCRIPTION
When WordPress is loaded locally, i.e. without a HTTP request, the expected `$_SERVER['REQUEST_METHOD']` is not set, resulting in `PHP Notice: Undefined index: REQUEST_METHOD in /path/to/wp-content/plugins/satispress/src/ServiceProvider.php on line 156` being logged.

The commit checks if WordPress is `DOING_CRON` and if so, returns a instantiated but unconfigured `Request` (`WP_REST_Request`) object.