### PR TITLE
Superflous/confusing line

### DIFF
--- a/src/Provider/Authentication.php
+++ b/src/Provider/Authentication.php
@@ -114,7 +114,6 @@ class Authentication extends AbstractHookProvider {
 				$user_id = $server->authenticate( $this->request );
 			} catch ( AuthenticationException $e ) {
 				$this->auth_status = $e;
-				$user_id           = false;
 
 				add_filter( 'rest_authentication_errors', [ $this, 'get_authentication_errors' ] );
 			}


### PR DESCRIPTION
I spent far too much time looking at this line before realising it doesn't do anything!

`$user_id` is already false here.