### PR TITLE
Fix type E_ERROR when wp_parse_url() returns null

### DIFF
--- a/src/Provider/Authentication.php
+++ b/src/Provider/Authentication.php
@@ -184,7 +184,7 @@ class Authentication extends AbstractHookProvider {
 	protected function get_request_path(): string {
 		$request_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 
-		if ( false === $request_path ) {
+		if ( ! $request_path ) {
 			return '';
 		}
 


### PR DESCRIPTION
The problem was supposedly fixed in #122 but I'm still seeing the error occasionally:

```
An error of type E_ERROR was caused in line 196 of the file /nas/content/live/fbpsatispress/wp-content/plugins/satispress/src/Provider/Authentication.php. Error message: Uncaught TypeError: ltrim() expects parameter 1 to be string, null given in /nas/content/live/fbpsatispress/wp-content/plugins/satispress/src/Provider/Authentication.php:196
Stack trace:
#0 /nas/content/live/fbpsatispress/wp-content/plugins/satispress/src/Provider/Authentication.php(196): ltrim(NULL, '/')
#1 /nas/content/live/fbpsatispress/wp-content/plugins/satispress/src/Provider/Authentication.php(163): SatisPress\Provider\Authentication->get_request_path()
#2 /nas/content/live/fbpsatispress/wp-content/plugins/satispress/src/Provider/Authentication.php(75): SatisPress\Provider\Authentication->is_satispress_request()
#3 /nas/content/live/fbpsatispress/wp-content/plugins/satispress/vendor/cedaro/wp-plugin/src/AbstractPlugin.php(180): SatisPress\Provider\Authentication->register_hooks()
#4 /nas/content/live/fbpsatispress/wp-content/plugins/satispress/satispress.php(74): Cedaro\WP\Plugin\AbstractPlugin->register_hooks(Object(SatisPress\Provider\Authentication))
#5 /nas/content/live/fbpsatispress/wp-settings.php
```

It seems like `wp_parse_url()` can return false _or_ null.

Related #126