### PR TITLE
feat: validate downloaded archive

### DIFF
--- a/src/Archiver.php
+++ b/src/Archiver.php
@@ -17,6 +17,7 @@ namespace SatisPress;
 
 use PclZip;
 use Psr\Log\LoggerInterface;
+use SatisPress\Exception\FileArchiveInvalid;
 use SatisPress\Exception\FileDownloadFailed;
 use SatisPress\Exception\FileOperationFailed;
 use SatisPress\Exception\InvalidReleaseVersion;
@@ -180,6 +181,20 @@ class Archiver {
 			);
 
 			throw FileDownloadFailed::forFileName( $filename );
+		}
+
+		$zip = new pclzip($tmpfname);
+
+		if ( $zip->properties()['status'] !== 'ok' ) {
+			$this->logger->error(
+				'File archive invalid.',
+				[
+					'error' => $tmpfname,
+					'url'   => $release->get_source_url(),
+				]
+			);
+
+			throw FileArchiveInvalid::forFileName( $filename );
 		}
 
 		if ( ! wp_mkdir_p( \dirname( $filename ) ) ) {

--- a/src/Exception/FileArchiveInvalid.php
+++ b/src/Exception/FileArchiveInvalid.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Invalid file archive exception.
+ *
+ * @package SatisPress
+ * @license GPL-2.0-or-later
+ * @since 0.5.2
+ */
+
+declare ( strict_types = 1 );
+
+namespace SatisPress\Exception;
+
+/**
+ * Invalid file archive exception class.
+ *
+ * @since 0.5.2
+ */
+class FileArchiveInvalid extends \RuntimeException implements SatispressException {
+	/**
+	 * Create an exception for invalid file archive.
+	 *
+	 * @since 0.5.2
+	 *
+	 * @param string     $filename File name.
+	 * @param int        $code     Optional. The Exception code.
+	 * @param \Throwable $previous Optional. The previous throwable used for the exception chaining.
+	 * @return FileArchiveInvalid
+	 */
+	public static function forFileName(
+		string $filename,
+		int $code = 0,
+		\Throwable $previous = null
+	): FileDownloadFailed {
+		$message = "Invalid archive for file {$filename}.";
+
+		return new static( $message, $code, $previous );
+	}
+}


### PR DESCRIPTION
Fixes #96

This checks if the downloaded archive is valid.

Tested with Envato Market updater, It failed because it stores an invalid download URL in plugin updates. SatisPress uses that URL and it downloads the HTML page and not the plugin/theme archive.

Should fix any plugin updater that fails with auth issues too.

> **Possible improvements:** It could add extra checks for an empty archive or the correct depth of the plugin.

ping: @bradyvercher