### PR TITLE
chore: Updating composer dev-dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
 	"require-dev": {
 		"brain/monkey": "^2.2",
 		"cedaro/wp-test-suite": "dev-develop",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
 		"phpcompatibility/phpcompatibility-wp": "^2",
 		"phpunit/phpunit": "^7.5",
 		"roave/security-advisories": "dev-master",


### PR DESCRIPTION
Updating composer dev-dependency `dealerdirect/phpcodesniffer-composer-installer` to latest version for Composer 2 compatibility.

This is in relation to #139 