### PR TITLE
Avoid space between the package name and version

### DIFF
--- a/views/templates.php
+++ b/views/templates.php
@@ -84,7 +84,7 @@ declare( strict_types = 1 );
 		</tr>
 		<tr>
 			<th scope="row"><label for="satispress-release-action-require-{{ data.name }}"><?php esc_html_e( 'Require', 'satispress' ); ?></label></th>
-			<td><input type="text" value='"{{ data.name }}": "{{ data.version }}"' class="regular-text" readonly="readonly" id="satispress-release-action-require-{{ data.name }}" /></td>
+			<td><input type="text" value='"{{ data.name }}":"{{ data.version }}"' class="regular-text" readonly="readonly" id="satispress-release-action-require-{{ data.name }}" /></td>
 		</tr>
 		<tr>
 			<td colspan="2">


### PR DESCRIPTION
Not sure if it ever worked with the space but I get this error:

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/36432/105172480-896b2880-5ad4-11eb-97fc-7a796494ae5c.png">

If I remove the space, it works fine.