### PR TITLE
Skip releases without a semver compliant version string

### DIFF
--- a/src/Transformer/ComposerRepositoryTransformer.php
+++ b/src/Transformer/ComposerRepositoryTransformer.php
@@ -19,6 +19,7 @@ use SatisPress\Package;
 use SatisPress\ReleaseManager;
 use SatisPress\Repository\PackageRepository;
 use SatisPress\VersionParser;
+use UnexpectedValueException;
 
 /**
  * Composer repository transformer class.
@@ -159,6 +160,15 @@ class ComposerRepositoryTransformer implements PackageRepositoryTransformer {
 			} catch ( FileNotFound $e ) {
 				$this->logger->error(
 					'Package artifact could not be found for {package}:{version}.',
+					[
+						'exception' => $e,
+						'package'   => $package->get_name(),
+						'version'   => $version,
+					]
+				);
+			} catch ( UnexpectedValueException $e ) {
+				$this->logger->error(
+					'Invalid version string for {package}:{version}.',
 					[
 						'exception' => $e,
 						'package'   => $package->get_name(),


### PR DESCRIPTION
Skip the invalid version release instead of crashing with an uncaught `UnexpectedValueException ` 

fixes #160 