### PR TITLE
Added a search field in package-selector.js

### DIFF
--- a/assets/js/components/package-selector.js
+++ b/assets/js/components/package-selector.js
@@ -1,9 +1,9 @@
 import { components, data, element, html, i18n } from '../utils/index.js';
 import { closeSmallIcon } from './icons.js';
 
-const { Button, CheckboxControl, Panel, PanelHeader, TabPanel } = components;
+const { Button, CheckboxControl, Panel, PanelHeader, TabPanel, TextControl } = components;
 const { useSelect } = data;
-const { Component } = element;
+const { useState } = element;
 const { __ } = i18n;
 
 function PackageSelector( props ) {
@@ -13,6 +13,8 @@ function PackageSelector( props ) {
 		onClose,
 		packages,
 	} = props;
+
+	const [ searchTerm, setSearchTerm ] = useState( '' );
 
 	const installedPackages = {
 		plugins: useSelect( ( select ) => select( 'satispress/packages' ).getPlugins() ),
@@ -46,8 +48,17 @@ function PackageSelector( props ) {
 
 	const tabContent = ( tab ) => {
 		const items = installedPackages[ tab.name ];
+		const searchTerms = searchTerm.toLowerCase().split(' ').filter( searchTerm => searchTerm );
+		const filteredItems = searchTerms.length === 0 ? items : items.filter( item => {
+			return searchTerms.some( searchTerm => {
+				const slugMatch = item.slug.toLowerCase().includes( searchTerm );
+				const nameMatch = item.name.toLowerCase().includes( searchTerm );
+				const authorMatch = item.author.toLowerCase().includes( searchTerm );
+				return slugMatch || nameMatch || authorMatch;
+			} );
+		} );
 
-		const listItems = items.map( item => {
+		const listItems = filteredItems.map( item => {
 			const { name, slug, type } = item;
 
 			return html`
@@ -61,7 +72,16 @@ function PackageSelector( props ) {
 			`;
 		} );
 
-		return html`<ul>${ listItems }</ul>`;
+		return html`<div>
+				<${ TextControl }
+					label=${ __( 'Search', 'satispress' ) + ' ' + tab.title }
+					hideLabelFromVision
+					placeholder=${ __( 'Search', 'satispress' ) + ' ' + tab.title }
+					onChange=${ setSearchTerm }
+					value=${ searchTerm }
+				/>
+			<ul>${ listItems }</ul>
+		</div>`;
 	};
 
 	return html`


### PR DESCRIPTION
A faster way to filter the plugins or themes list on the "settings > SatisPress" page.

When searching on this page using the browser's search function, plugin and theme names will be found multiple times on the page. This is a bit cumbersome when you have a long list of plugins.

This PR adds a search field in the "manage packages" sidebar, in order to efficiently filter the list of plugins and themes.

The new search field:
- is case-insensitive
- can search through package slug, name, and author name
- supports multiple search terms (divided by a space in the search field)