### PR TITLE
Allow `composer/installers` `v2`

### DIFF
--- a/src/Transformer/ComposerRepositoryTransformer.php
+++ b/src/Transformer/ComposerRepositoryTransformer.php
@@ -147,7 +147,7 @@ class ComposerRepositoryTransformer implements PackageRepositoryTransformer {
 						'shasum' => $this->release_manager->checksum( 'sha1', $release ),
 					],
 					'require'            => [
-						'composer/installers' => '^1.0 || ^2.0';
+						'composer/installers' => '^1.0 || ^2.0',
 					],
 					'type'               => $package->get_type(),
 					'authors'            => [

--- a/src/Transformer/ComposerRepositoryTransformer.php
+++ b/src/Transformer/ComposerRepositoryTransformer.php
@@ -147,7 +147,7 @@ class ComposerRepositoryTransformer implements PackageRepositoryTransformer {
 						'shasum' => $this->release_manager->checksum( 'sha1', $release ),
 					],
 					'require'            => [
-						'composer/installers' => '^1.0',
+						'composer/installers' => '^1.0 || ^2.0';
 					],
 					'type'               => $package->get_type(),
 					'authors'            => [


### PR DESCRIPTION
This adds support for `composer/installers` `v2`.

See https://github.com/outlandishideas/wpackagist/pull/431 for a similar PR.

Note that I made a typo on the first commit and a faulty commit message, so it might make sense to squash merge the PR.