### PR TITLE
Remove `node_modules` from dirs to be excluded from archives

### DIFF
--- a/src/Archiver.php
+++ b/src/Archiver.php
@@ -143,7 +143,6 @@ class Archiver {
 			$excludes = [
 				'.DS_Store',
 				'.git',
-				'node_modules',
 			];
 		}
 


### PR DESCRIPTION
Removes `node_modules` from the list of folders to be excluded from archives.

Closes #173. See this issue for background.