### PR TITLE
Add package name to SatisPress list

### DIFF
--- a/assets/js/components/package-table.js
+++ b/assets/js/components/package-table.js
@@ -28,6 +28,10 @@ function PackageTable( props ) {
 					<td colSpan="2">${ description }</td>
 				</tr>
 				<tr>
+					<th>${ __( 'Name', 'satispress' ) }</th>
+					<td>${ name }</td>
+				</tr>
+				<tr>
 					<th>${ __( 'Homepage', 'satispress' ) }</th>
 					<td><a href="${ homepage }" target="_blank" rel="noopener noreferer">${ homepage }</a></td>
 				</tr>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
The list of enabled packages ("Settings" -> "SatisPress" -> tab "Repository") includes the Composer name, description, author, package type, etc. However, it does not include the package _name_. This sometimes makes it hard to identify a package.
Example: A plugin called "WPO365 | SYNC" has Composer name `satispress/wpo365-login-premium`, another one is called "WPO365 | LOGIN PLUS", Composer name `wpo365-login-professional`.
Without looking at the code, you won't know which plugin is what.


**What is the new behavior (if this is a feature change)?**
The package name is printed below the description, above the homepage.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
The `name` property was already there but unused. I haven't tested the change locally because I did it on the GitHub UI only.