### PR TITLE
Require Roave Security Advisories as `dev-latest`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
 		"phpcompatibility/phpcompatibility-wp": "^2",
 		"phpunit/phpunit": "^7.5",
-		"roave/security-advisories": "dev-master",
+		"roave/security-advisories": "dev-latest",
 		"squizlabs/php_codesniffer": "^3.3",
 		"wordpress/wordpress": "^5.1",
 		"wp-cli/i18n-command": "dev-main",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Chore


**What is the current behavior?** (You can also link to an open issue here)
`roave/security-advisories` is required with `dev-master` constraint.


**What is the new behavior (if this is a feature change)?**
`roave/security-advisories` is required with `dev-latest` constraint.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
From https://github.com/Roave/SecurityAdvisories:
> Simply add `"roave/security-advisories": "dev-latest"` to your `composer.json` `"require-dev"` section […]