### PR TITLE
Unescape visible code tags in release-actions component

### DIFF
--- a/assets/js/components/release-actions.js
+++ b/assets/js/components/release-actions.js
@@ -1,6 +1,7 @@
-import { components, html, i18n } from '../utils/index.js';
+import { components, element, html, i18n } from '../utils/index.js';
 
 const { Button, TextControl } = components;
+const { createElement, createInterpolateElement } = element;
 const { __, sprintf } = i18n;
 
 const selectField = ( e ) => e.nativeEvent.target.select();
@@ -19,8 +20,10 @@ function  ReleaseActions( props ) {
 	/* translators: %s: version number */
 	const buttonText = __( 'Download %s', 'satispress' );
 
-	/* translators: %s: <code>composer.json</code> */
-	const copyPasteText = __( 'Copy and paste into %s', 'satispress' );
+	const copyPasteHtml = createInterpolateElement(
+		__( 'Copy and paste into <code>composer.json</code>', 'satispress' ),
+		{ code: createElement( 'code' ) }
+	);
 
 	return html`
 		<div className="satispress-release-actions">
@@ -51,7 +54,7 @@ function  ReleaseActions( props ) {
 								onClick=${ selectField }
 							/>
 							<span className="description">
-								<em>${ sprintf( copyPasteText, '<code>composer.json</code>' ) }</em>
+								<em>${ copyPasteHtml }</em>
 							</span>
 						</td>
 					</tr>


### PR DESCRIPTION
The combination of the tagged template literal, and `sprintf()` in a placeholder, means that the `<code>` tags around the `composer.json` file name are visible in the release actions:

<img width="609" alt="Screenshot 2022-11-12 at 01 09 25" src="https://user-images.githubusercontent.com/88371/201450742-02c6b990-ac25-4ba4-b306-93f8a344d5c3.png">

While the most straightforward and sensible thing to do would be to just remove the tags / `sprintf()`, I tried to see if I could unescape them. There may be a simpler way than this messy and non-performant hack, that I stole from [here](https://github.com/developit/htm/issues/76#issuecomment-478774498).

It works though:

<img width="609" alt="Screenshot 2022-11-12 at 02 02 38" src="https://user-images.githubusercontent.com/88371/201451370-0b43151d-a9f0-427b-a294-8f80b7504d9c.png">

This is the only instance in the code where a JS `sprintf()` call in a template literal is used with a replacement value that includes HTML that should be treated as HTML.