### PR TITLE
Replace deprecated `${var}` with `{$var}`

### DIFF
--- a/src/HTTP/Response.php
+++ b/src/HTTP/Response.php
@@ -117,7 +117,7 @@ class Response {
 	 */
 	public function set_status( int $status_code ) {
 		if ( $status_code < 100 || $status_code > 599 ) {
-			throw new \InvalidArgumentException( "Invalid status code '${status_code}'." );
+			throw new \InvalidArgumentException( "Invalid status code '{$status_code}'." );
 		}
 
 		$this->status_code = $status_code;


### PR DESCRIPTION
Fixes a small deprecation in PHP 8. `${var}` has to be written like this now: `{$var}`.