### PR TITLE
Fix implicit nullable types for PHP 8.4 support

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -82,4 +82,7 @@
 			<property name="blank_line_check" value="true"/>
 		</properties>
 	</rule>
+
+	<!-- Catch implicitly nullable types (deprecated in PHP 8.4) -->
+	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
 		"phpcompatibility/phpcompatibility-wp": "^2",
 		"phpunit/phpunit": "^8",
 		"roave/security-advisories": "dev-latest",
+		"slevomat/coding-standard": "^8.22",
 		"squizlabs/php_codesniffer": "^3.3",
 		"wordpress/wordpress": "^6.6",
 		"wp-cli/i18n-command": "dev-main",

--- a/src/Authentication/ApiKey/ApiKey.php
+++ b/src/Authentication/ApiKey/ApiKey.php
@@ -59,7 +59,7 @@ final class ApiKey implements ArrayAccess {
 	 * @param string  $token API key token.
 	 * @param array   $data  Optional. Additional data associated with the key.
 	 */
-	public function __construct( WP_User $user, string $token, array $data = null ) {
+	public function __construct( WP_User $user, string $token, ?array $data = null ) {
 		$this->user  = $user;
 		$this->token = $token;
 		$this->data  = $data ?? [];
@@ -85,7 +85,7 @@ final class ApiKey implements ArrayAccess {
 	 * @param string $format Optional. Date format.
 	 * @return mixed
 	 */
-	public function get_date( string $name, string $format = null ) {
+	public function get_date( string $name, ?string $format = null ) {
 		if ( empty( $this->data[ $name ] ) ) {
 			return '';
 		}
@@ -153,7 +153,7 @@ final class ApiKey implements ArrayAccess {
 	 * @param string $format    Optional. Date format.
 	 * @return string
 	 */
-	private function format_date( int $timestamp, string $format = null ): string {
+	private function format_date( int $timestamp, ?string $format = null ): string {
 		$format      = $format ?: get_option( 'date_format' );
 		$timezone_id = get_option( 'timezone_string' );
 		$datetime    = new DateTime();

--- a/src/Authentication/ApiKey/Factory.php
+++ b/src/Authentication/ApiKey/Factory.php
@@ -31,7 +31,7 @@ final class Factory {
 	 * @param string  $token Optional. API Key token.
 	 * @return ApiKey
 	 */
-	public function create( WP_User $user, array $data = null, string $token = null ): ApiKey {
+	public function create( WP_User $user, ?array $data = null, ?string $token = null ): ApiKey {
 		$data = $data ?? [];
 
 		if ( ! isset( $data['created'] ) ) {

--- a/src/ComposerVersionParser.php
+++ b/src/ComposerVersionParser.php
@@ -47,7 +47,7 @@ final class ComposerVersionParser implements VersionParser {
 	 * @param string $full_version Optional complete version string to give more context.
 	 * @return string Normalized version string.
 	 */
-	public function normalize( string $version, string $full_version = null ): string {
+	public function normalize( string $version, ?string $full_version = null ): string {
 		return $this->parser->normalize( $version, $full_version );
 	}
 }

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -52,7 +52,7 @@ class AuthenticationException extends HttpException {
 		string $message,
 		int $status_code = HTTP::INTERNAL_SERVER_ERROR,
 		array $headers = [],
-		Throwable $previous = null
+		?Throwable $previous = null
 	) {
 		$this->code    = $code;
 		$this->headers = $headers;
@@ -73,7 +73,7 @@ class AuthenticationException extends HttpException {
 	public static function forAuthenticationRequired(
 		array $headers = [],
 		string $code = 'invalid_request',
-		Throwable $previous = null
+		?Throwable $previous = null
 	): HttpException {
 		$headers = $headers ?: [ 'WWW-Authenticate' => 'Basic realm="SatisPress"' ];
 		$message = 'Authentication is required for this resource.';
@@ -94,7 +94,7 @@ class AuthenticationException extends HttpException {
 	public static function forInvalidCredentials(
 		array $headers = [],
 		string $code = 'invalid_credentials',
-		Throwable $previous = null
+		?Throwable $previous = null
 	): HttpException {
 		$headers = $headers ?: [ 'WWW-Authenticate' => 'Basic realm="SatisPress"' ];
 		$message = 'Invalid credentials.';
@@ -115,7 +115,7 @@ class AuthenticationException extends HttpException {
 	public static function forMissingAuthorizationHeader(
 		array $headers = [],
 		string $code = 'invalid_credentials',
-		Throwable $previous = null
+		?Throwable $previous = null
 	): HttpException {
 		$headers = $headers ?: [ 'WWW-Authenticate' => 'Basic realm="SatisPress"' ];
 		$message = 'Missing authorization header.';

--- a/src/Exception/FileDownloadFailed.php
+++ b/src/Exception/FileDownloadFailed.php
@@ -30,7 +30,7 @@ class FileDownloadFailed extends \RuntimeException implements SatispressExceptio
 	public static function forFileName(
 		string $filename,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): FileDownloadFailed {
 		$message = "Artifact download failed for file {$filename}.";
 

--- a/src/Exception/FileNotFound.php
+++ b/src/Exception/FileNotFound.php
@@ -28,7 +28,7 @@ class FileNotFound extends \RuntimeException implements SatispressException {
 	public static function forInvalidChecksum(
 		string $filename,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): FileNotFound {
 		$message = "Cannot compute a checksum for an unknown file at {$filename}.";
 

--- a/src/Exception/FileOperationFailed.php
+++ b/src/Exception/FileOperationFailed.php
@@ -32,7 +32,7 @@ class FileOperationFailed extends \RuntimeException implements SatispressExcepti
 		string $filename,
 		string $destination,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): FileOperationFailed {
 		$message = "Unable to move release artifact {$filename} to storage: {$destination}.";
 
@@ -52,7 +52,7 @@ class FileOperationFailed extends \RuntimeException implements SatispressExcepti
 	public static function unableToCreateTemporaryDirectory(
 		string $filename,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): FileOperationFailed {
 		$directory = \dirname( $filename );
 		$message   = "Unable to create temporary directory: {$directory}.";
@@ -73,7 +73,7 @@ class FileOperationFailed extends \RuntimeException implements SatispressExcepti
 	public static function unableToCreateZipFile(
 		string $filename,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): FileOperationFailed {
 		$message = "Unable to create zip file for {$filename}.";
 
@@ -95,7 +95,7 @@ class FileOperationFailed extends \RuntimeException implements SatispressExcepti
 		string $filename,
 		string $tmpfname,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): FileOperationFailed {
 		$message = "Unable to rename temporary artifact {$tmpfname} to {$filename}.";
 

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -43,7 +43,7 @@ class HttpException extends \Exception implements SatispressException {
 		string $message,
 		int $status_code = HTTP::INTERNAL_SERVER_ERROR,
 		int $code = 0,
-		Throwable $previous = null
+		?Throwable $previous = null
 	) {
 		$this->status_code = $status_code;
 		$message           = $message ?: 'Internal Server Error';
@@ -62,7 +62,7 @@ class HttpException extends \Exception implements SatispressException {
 	 */
 	public static function forForbiddenResource(
 		int $code = 0,
-		Throwable $previous = null
+		?Throwable $previous = null
 	): HttpException {
 		$user_id     = get_current_user_id();
 		$request_uri = $_SERVER['REQUEST_URI'];
@@ -84,7 +84,7 @@ class HttpException extends \Exception implements SatispressException {
 	public static function forUnknownPackage(
 		string $slug,
 		int $code = 0,
-		Throwable $previous = null
+		?Throwable $previous = null
 	): HttpException {
 		$message = "Package does not exist; Package: {$slug}";
 
@@ -104,7 +104,7 @@ class HttpException extends \Exception implements SatispressException {
 	public static function forForbiddenPackage(
 		Package $package,
 		int $code = 0,
-		Throwable $previous = null
+		?Throwable $previous = null
 	): HttpException {
 		$user_id = get_current_user_id();
 		$slug    = $package->get_slug();
@@ -128,7 +128,7 @@ class HttpException extends \Exception implements SatispressException {
 		Package $package,
 		string $version,
 		int $code = 0,
-		Throwable $previous = null
+		?Throwable $previous = null
 	): HttpException {
 		$name    = $package->get_name();
 		$message = "An artifact for {$name} {$version} does not exist.";
@@ -149,7 +149,7 @@ class HttpException extends \Exception implements SatispressException {
 	public static function forMissingRelease(
 		Release $release,
 		int $code = 0,
-		Throwable $previous = null
+		?Throwable $previous = null
 	): HttpException {
 		$name    = $release->get_package()->get_name();
 		$version = $release->get_version();

--- a/src/Exception/InvalidFileName.php
+++ b/src/Exception/InvalidFileName.php
@@ -32,7 +32,7 @@ class InvalidFileName extends \InvalidArgumentException implements SatispressExc
 		string $filename,
 		int $validation_code,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): InvalidFileName {
 		$message = "File name '{$filename}' ";
 

--- a/src/Exception/InvalidPackageArtifact.php
+++ b/src/Exception/InvalidPackageArtifact.php
@@ -30,7 +30,7 @@ class InvalidPackageArtifact extends \RuntimeException implements SatispressExce
 	public static function unreadableZip(
 		string $filename,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): InvalidPackageArtifact {
 		$message = "Unable to parse {$filename} as a valid zip archive.";
 
@@ -50,7 +50,7 @@ class InvalidPackageArtifact extends \RuntimeException implements SatispressExce
 	public static function containsMacOsxDirectory(
 		string $filename,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): InvalidPackageArtifact {
 		$message = "Package artifact {$filename} has a top level __MACOSX directory.";
 

--- a/src/Exception/InvalidReleaseSource.php
+++ b/src/Exception/InvalidReleaseSource.php
@@ -32,7 +32,7 @@ class InvalidReleaseSource extends \LogicException implements SatispressExceptio
 	public static function forRelease(
 		Release $release,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): InvalidReleaseSource {
 		$name = $release->get_package()->get_name();
 

--- a/src/Exception/InvalidReleaseVersion.php
+++ b/src/Exception/InvalidReleaseVersion.php
@@ -32,7 +32,7 @@ class InvalidReleaseVersion extends \LogicException implements SatispressExcepti
 		string $version,
 		string $package_name,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): InvalidReleaseVersion {
 		$message = "Invalid release version for {$package_name}: {$version}";
 
@@ -52,7 +52,7 @@ class InvalidReleaseVersion extends \LogicException implements SatispressExcepti
 	public static function hasNoReleases(
 		string $package_name,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): InvalidReleaseVersion {
 		$message = "Package {$package_name} has no releases.";
 

--- a/src/Exception/PackageNotInstalled.php
+++ b/src/Exception/PackageNotInstalled.php
@@ -34,7 +34,7 @@ class PackageNotInstalled extends \RuntimeException implements SatispressExcepti
 		string $method,
 		Package $package,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): PackageNotInstalled {
 		$name    = $package->get_name();
 		$message = "Cannot call method {$method} for a package that is not installed; Package: {$name}.";
@@ -55,7 +55,7 @@ class PackageNotInstalled extends \RuntimeException implements SatispressExcepti
 	public static function unableToArchiveFromSource(
 		Package $package,
 		int $code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	): PackageNotInstalled {
 		$name    = $package->get_name();
 		$message = "Unable to archive {$package}; source does not exist.";

--- a/src/Htaccess.php
+++ b/src/Htaccess.php
@@ -40,7 +40,7 @@ class Htaccess {
 	 *
 	 * @param string $path Optional. Directory path where .htaccess is located. Default is empty string.
 	 */
-	public function __construct( string $path = null ) {
+	public function __construct( ?string $path = null ) {
 		if ( null === $path ) {
 			$path = '';
 		}

--- a/src/PackageType/ThemeBuilder.php
+++ b/src/PackageType/ThemeBuilder.php
@@ -28,7 +28,7 @@ final class ThemeBuilder extends PackageBuilder {
 	 * @param WP_Theme $theme Optional. Theme instance.
 	 * @return ThemeBuilder
 	 */
-	public function from_source( string $slug, WP_Theme $theme = null ): self {
+	public function from_source( string $slug, ?WP_Theme $theme = null ): self {
 		if ( null === $theme ) {
 			$theme = wp_get_theme( $slug );
 		}

--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -29,5 +29,5 @@ interface VersionParser {
 	 * @param string $full_version Optional complete version string to give more context.
 	 * @return string Normalized version string.
 	 */
-	public function normalize( string $version, string $full_version = null ): string;
+	public function normalize( string $version, ?string $full_version = null ): string;
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -100,7 +100,7 @@ function get_authorization_header() {
  * @param array $args Optional. Query string parameters. Default is an empty array.
  * @return string
  */
-function get_packages_permalink( array $args = null ): string {
+function get_packages_permalink( ?array $args = null ): string {
 	if ( null === $args ) {
 		$args = [];
 	}


### PR DESCRIPTION
[PHP 8.4 deprecated the use of implicit nullable types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types), e.g. `function foo(string $var = null)`. SatisPress had used these in a number of spots, leading to deprecation notices being emitted.

This PR corrects all the instances I could find, switching them to explicit nullables with a null default (e.g. `?string $var = null`). This provides support for all PHP versions from 7.1 onward, which is below this project's baseline.

I've run this on my own site for a few days now without issue, and the tests appear to pass as well.

I made the change using the `SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue` sniff from `slevomat/coding-standard`, as the PHP RFC suggested under [migration paths](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types#impact_analysis_and_migration_paths).

I _did_ leave the coding standard and this single sniff in place in `.phpcs.xml.dist` as a useful guardrail for future development; however, I could remove it if you don't want it there. (No other part of the standard is applied.) As a future alternative, version 3 of the PHPCompatibility-WP standard will catch implicit nullables. But since it's still only available as [an alpha release](https://github.com/PHPCompatibility/PHPCompatibilityWP/releases), and may have effects beyond this PR's scope, I opted for a currently-stable path.