### PR TITLE
WordPress 6.8 compatibility: Add __next40pxDefaultSize to remaining controls to prevent deprecation notices.

### DIFF
--- a/assets/js/components/access-table.js
+++ b/assets/js/components/access-table.js
@@ -76,8 +76,8 @@ function AccessTableRow( props ) {
 					value=${ token }
 					readOnly
 					onClick=${ selectField }
-					__nextHasNoMarginBottom={ true }
-					__next40pxDefaultSize={ true }
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</td>
 			<td className="column-last-used">${ last_used || '—' }</td>

--- a/assets/js/components/access-table.js
+++ b/assets/js/components/access-table.js
@@ -77,6 +77,7 @@ function AccessTableRow( props ) {
 					readOnly
 					onClick=${ selectField }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize={ true }
 				/>
 			</td>
 			<td className="column-last-used">${ last_used || '—' }</td>

--- a/assets/js/components/access-table.js
+++ b/assets/js/components/access-table.js
@@ -76,7 +76,7 @@ function AccessTableRow( props ) {
 					value=${ token }
 					readOnly
 					onClick=${ selectField }
-					__nextHasNoMarginBottom
+					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
 				/>
 			</td>

--- a/assets/js/components/api-key-form.js
+++ b/assets/js/components/api-key-form.js
@@ -23,7 +23,7 @@ function ApiKeyForm( { onSubmit } ) {
 					placeholder=${ __( 'Name', 'satispress' ) }
 					onChange=${ setName }
 					value=${ name }
-					__nextHasNoMarginBottom
+					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
 				/>
 			</${ FlexItem }>

--- a/assets/js/components/api-key-form.js
+++ b/assets/js/components/api-key-form.js
@@ -24,6 +24,7 @@ function ApiKeyForm( { onSubmit } ) {
 					onChange=${ setName }
 					value=${ name }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize={ true }
 				/>
 			</${ FlexItem }>
 			<${ FlexItem }>

--- a/assets/js/components/api-key-form.js
+++ b/assets/js/components/api-key-form.js
@@ -23,8 +23,8 @@ function ApiKeyForm( { onSubmit } ) {
 					placeholder=${ __( 'Name', 'satispress' ) }
 					onChange=${ setName }
 					value=${ name }
-					__nextHasNoMarginBottom={ true }
-					__next40pxDefaultSize={ true }
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			</${ FlexItem }>
 			<${ FlexItem }>

--- a/assets/js/components/package-selector.js
+++ b/assets/js/components/package-selector.js
@@ -67,7 +67,7 @@ function PackageSelector( props ) {
 						checked=${ packageExists( slug, type ) }
 						onChange=${ checked => togglePackage( slug, type, checked ) }
 						label=${ name }
-						__nextHasNoMarginBottom
+						__nextHasNoMarginBottom={ true }
 					/>
 				</li>
 			`;
@@ -80,7 +80,7 @@ function PackageSelector( props ) {
 					placeholder=${ __( 'Search', 'satispress' ) + ' ' + tab.title }
 					onChange=${ setSearchTerm }
 					value=${ searchTerm }
-					__nextHasNoMarginBottom
+					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
 				/>
 			<ul>${ listItems }</ul>

--- a/assets/js/components/package-selector.js
+++ b/assets/js/components/package-selector.js
@@ -67,7 +67,7 @@ function PackageSelector( props ) {
 						checked=${ packageExists( slug, type ) }
 						onChange=${ checked => togglePackage( slug, type, checked ) }
 						label=${ name }
-						__nextHasNoMarginBottom={ true }
+						__nextHasNoMarginBottom
 					/>
 				</li>
 			`;
@@ -80,8 +80,8 @@ function PackageSelector( props ) {
 					placeholder=${ __( 'Search', 'satispress' ) + ' ' + tab.title }
 					onChange=${ setSearchTerm }
 					value=${ searchTerm }
-					__nextHasNoMarginBottom={ true }
-					__next40pxDefaultSize={ true }
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
 				/>
 			<ul>${ listItems }</ul>
 		</div>`;

--- a/assets/js/components/package-selector.js
+++ b/assets/js/components/package-selector.js
@@ -81,6 +81,7 @@ function PackageSelector( props ) {
 					onChange=${ setSearchTerm }
 					value=${ searchTerm }
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize={ true }
 				/>
 			<ul>${ listItems }</ul>
 		</div>`;

--- a/assets/js/components/release-actions.js
+++ b/assets/js/components/release-actions.js
@@ -39,6 +39,7 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-download-url-${ composerName }"
 								onClick=${ selectField }
+								__nextHasNoMarginBottom={ true }
 								__next40pxDefaultSize={ true }
 							/>
 						</td>
@@ -53,6 +54,7 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-require-${ composerName }"
 								onClick=${ selectField }
+								__nextHasNoMarginBottom={ true }
 								__next40pxDefaultSize={ true }
 							/>
 							<span className="description">
@@ -70,6 +72,7 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-cli-${ composerName }"
 								onClick=${ selectField }
+								__nextHasNoMarginBottom={ true }
 								__next40pxDefaultSize={ true }
 							/>
 						</td>

--- a/assets/js/components/release-actions.js
+++ b/assets/js/components/release-actions.js
@@ -39,6 +39,7 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-download-url-${ composerName }"
 								onClick=${ selectField }
+								__next40pxDefaultSize={ true }
 							/>
 						</td>
 					</tr>
@@ -52,6 +53,7 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-require-${ composerName }"
 								onClick=${ selectField }
+								__next40pxDefaultSize={ true }
 							/>
 							<span className="description">
 								<em>${ copyPasteHtml }</em>
@@ -68,6 +70,7 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-cli-${ composerName }"
 								onClick=${ selectField }
+								__next40pxDefaultSize={ true }
 							/>
 						</td>
 					</tr>

--- a/assets/js/components/release-actions.js
+++ b/assets/js/components/release-actions.js
@@ -39,8 +39,8 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-download-url-${ composerName }"
 								onClick=${ selectField }
-								__nextHasNoMarginBottom={ true }
-								__next40pxDefaultSize={ true }
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 							/>
 						</td>
 					</tr>
@@ -54,8 +54,8 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-require-${ composerName }"
 								onClick=${ selectField }
-								__nextHasNoMarginBottom={ true }
-								__next40pxDefaultSize={ true }
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 							/>
 							<span className="description">
 								<em>${ copyPasteHtml }</em>
@@ -72,8 +72,8 @@ function  ReleaseActions( props ) {
 								readOnly="readonly"
 								id="satispress-release-action-cli-${ composerName }"
 								onClick=${ selectField }
-								__nextHasNoMarginBottom={ true }
-								__next40pxDefaultSize={ true }
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 							/>
 						</td>
 					</tr>

--- a/src/Provider/AdminAssets.php
+++ b/src/Provider/AdminAssets.php
@@ -45,7 +45,7 @@ class AdminAssets extends AbstractHookProvider {
 			'satispress-access',
 			$this->plugin->get_url( 'assets/js/access.js' ),
 			[ 'wp-components', 'wp-data', 'wp-data-controls', 'wp-element', 'wp-i18n' ],
-			'20210211',
+			'20251204',
 			true
 		);
 
@@ -59,7 +59,7 @@ class AdminAssets extends AbstractHookProvider {
 			'satispress-repository',
 			$this->plugin->get_url( 'assets/js/repository.js' ),
 			[ 'wp-components', 'wp-data', 'wp-data-controls', 'wp-element', 'wp-i18n' ],
-			'20210211',
+			'20251204',
 			true
 		);
 


### PR DESCRIPTION
Proposed changes:

* This PR adds `__next40pxDefaultSize` to multiple control components, to prevent deprecation notices.
    Currently there doesn't appear to be a dev-note posts about this, but the full list can be found here: https://github.com/WordPress/gutenberg/issues/69549
* This PR only covers the following controls: TextControl. See https://github.com/WordPress/gutenberg/pull/66745
* This also adds missing `__nextHasNoMarginBottom` to cover WordPress 6.7 deprecation notices.

(cherry picked from commit 41bde9f8893981218f6c6e468b9804f5add403d8)
(cherry picked from commit 40bdd06033fd7f86fcce302966a907f272d3fb09)
(cherry picked from commit 33c59b0677655cf9a9629d03d6265fd6b116fbdc)
(cherry picked from commit 700fbdf74ebf8824ef11d43dac4d600d84f06d91)

See fork PR https://github.com/thefrosty/satispress/pull/13